### PR TITLE
Feature/166 problem with imitial tempo

### DIFF
--- a/tracker/app/cust_iso_midi_file_in.py
+++ b/tracker/app/cust_iso_midi_file_in.py
@@ -70,8 +70,9 @@ class CustMidiFileInputDevice(MidiFileInputDevice):
 
 
         # log.info("Loading MIDI data from %s, ticks per beat = %d" % (self.filename, self.midi_reader.ticks_per_beat))
-        note_tracks = list(filter(lambda tr: any(message.type == 'note_on' for message in tr),
-                                  self.midi_reader.tracks))
+        # note_tracks = list(filter(lambda tr: any(message.type == 'note_on' for message in tr),
+        #                           self.midi_reader.tracks))
+        note_tracks = self.midi_reader.tracks
         if not note_tracks:
             raise ValueError("Could not find any tracks with note data")
 

--- a/tracker/app/midi_dev.py
+++ b/tracker/app/midi_dev.py
@@ -12,10 +12,10 @@ log = logging.getLogger(__name__)
 
 class MidiFileManyTracksOutputDevice(iso.MidiFileOutputDevice):
 
-    def __init__(self, filename):
+    def __init__(self, filename, ticks_per_beat=iso.DEFAULT_TICKS_PER_BEAT):
         self.filename = filename
         # self.midifile = None
-        self.midifile = mido.MidiFile()
+        self.midifile = mido.MidiFile(ticks_per_beat=ticks_per_beat)
         # self.miditrack = []
         self.miditrack = [mido.MidiTrack()]
         self.midifile.tracks.append(self.miditrack[0])
@@ -222,8 +222,8 @@ class MidiFileManyTracksOutputDevice(iso.MidiFileOutputDevice):
 
 class FileOut(MidiFileManyTracksOutputDevice, iso.MidiOutputDevice):
 
-    def __init__(self, filename, device_name, send_clock, virtual=False):
-        MidiFileManyTracksOutputDevice.__init__(self, filename=filename)
+    def __init__(self, filename, device_name, send_clock, virtual=False, ticks_per_beat=iso.DEFAULT_TICKS_PER_BEAT):
+        MidiFileManyTracksOutputDevice.__init__(self, filename=filename, ticks_per_beat=ticks_per_beat)
         iso.MidiOutputDevice.__init__(self, device_name=device_name, send_clock=send_clock, virtual=virtual)
 
     def note_off(self, note, channel, track_idx=0):

--- a/tracker/app/tracker.py
+++ b/tracker/app/tracker.py
@@ -478,9 +478,9 @@ class Tracker:
                               denominator=self.time_signature['denominator'], time=0)
 
 
-        clock_source = Clock(tempo=120, ticks_per_beat=self.input_ticks_per_beat)
-        # self.timeline = iso.Timeline(120, output_device=self.midi_out, ticks_per_beat=ticks_per_beat)
-        self.timeline = iso.Timeline(output_device=self.midi_out, clock_source=clock_source)
+        # clock_source = Clock(tempo=120, ticks_per_beat=self.input_ticks_per_beat)
+        self.timeline = iso.Timeline(120, output_device=self.midi_out, ticks_per_beat=self.input_ticks_per_beat)
+        # self.timeline = iso.Timeline(output_device=self.midi_out, clock_source=clock_source)
         x = 1
 
 

--- a/tracker/tests/test_wrk_2.py
+++ b/tracker/tests/test_wrk_2.py
@@ -40,6 +40,7 @@ def test_note_at_beat():
     filename = os.path.join(this_dir, '..', 'tests', 'x1x1a.mid')
     filename = os.path.join(this_dir, '..', 'tests', 'x1x1b.mid')
     filename = os.path.join(this_dir, '..', 'tests', 'x1x1ax2.mid')
+    filename = os.path.join(this_dir, '..', 'tests', 'Pirates of the Caribbean.mid')
     # filename = os.path.join(this_dir, '..', '..', 'x1x1b.mid')
     file_input_device = iso.MidiFileInputDevice(filename)
     # file_content = file_input_device.read()

--- a/tracker/utils/dump_midi.py
+++ b/tracker/utils/dump_midi.py
@@ -61,8 +61,8 @@ def direct_midi_play():
     # filename = os.path.join(this_dir, '..', 'tests', 'xoutput_20231210213312.mid')
 
     # filename = os.path.join(this_dir, '..', 'tests', 'aedited_src_Var_tempo_2_trks_sax_piano.mid')
-
-    # print_mid(filename)
+    filename = os.path.join(this_dir, '..', 'saved_midi_files', 'xoutput.mid')
+    print_mid(filename)
 
     # filename = os.path.join(this_dir, '..','..','checks', 'test2.mid')
     # filename = os.path.join(this_dir, '..', 'tests', 'x1x1b.mid')

--- a/tracker/utils/dump_midi.py
+++ b/tracker/utils/dump_midi.py
@@ -62,7 +62,7 @@ def direct_midi_play():
 
     # filename = os.path.join(this_dir, '..', 'tests', 'aedited_src_Var_tempo_2_trks_sax_piano.mid')
 
-    print_mid(filename)
+    # print_mid(filename)
 
     # filename = os.path.join(this_dir, '..','..','checks', 'test2.mid')
     # filename = os.path.join(this_dir, '..', 'tests', 'x1x1b.mid')
@@ -75,9 +75,10 @@ def direct_midi_play():
     filename = os.path.join(this_dir, '..', 'tests', 'x1x1_dedup_tgt.mid')
     filename = os.path.join(this_dir, '..', 'tests', 'xoutput_20231209230252.mid')
     filename = os.path.join(this_dir, '..', 'tests', 'x1x1b.mid')
-    filename = os.path.join(this_dir, '..', 'saved_midi_files', 'xoutput.mid')
+    filename = os.path.join(this_dir, '..', 'tests', 'Pirates of the Caribbean.mid')
+    # filename = os.path.join(this_dir, '..', 'saved_midi_files', 'xoutput.mid')
     print_mid(filename)
 
-
+#
 if __name__ == '__main__':
     direct_midi_play()


### PR DESCRIPTION
1. remove filtering of non-note tracks
2. implementation of ticks_per_beat midi file out in order to enable synchronization between midi input and isobar output (this is needed to right synchronization) of tracks.
